### PR TITLE
ci: add Claude Code @claude-mention reviewer workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,48 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Resolve PR head SHA on issue_comment
+        id: pr-ref
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          SHA=$(gh api "repos/${REPO}/pulls/${ISSUE_NUMBER}" --jq .head.sha)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr-ref.outputs.sha || github.ref }}
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.pr-ref.outputs.sha || github.ref }}
+          ref: ${{ steps.pr-ref.outputs.sha || github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
 
       - name: Run Claude Code


### PR DESCRIPTION
## Summary

Wires up `anthropics/claude-code-action@v1` so commenting `@claude` on a PR or issue invokes Claude Code in CI. Mention-only trigger (no auto-run on every PR open) for cost control.

Auth uses `CLAUDE_CODE_OAUTH_TOKEN` (from a Claude Pro/Max subscription via `claude setup-token`) instead of `ANTHROPIC_API_KEY`, so usage counts against the existing subscription rather than per-token API billing.

Folds in the fix from [`mcp-server-synology#16`](https://github.com/atom2ueki/mcp-server-synology/pull/16): on `issue_comment` events, `actions/checkout` defaults to `GITHUB_REF` which points to the default branch — not the PR head. The workflow resolves the PR head SHA via the GitHub API first, then passes it to checkout (SHA, not ref name, to avoid races if the head moves between trigger and checkout).

Ported from [`mcp-server-synology#15`](https://github.com/atom2ueki/mcp-server-synology/pull/15) + [`#16`](https://github.com/atom2ueki/mcp-server-synology/pull/16).

## Setup status

- [x] \`CLAUDE_CODE_OAUTH_TOKEN\` already added to repo secrets
- [ ] Confirm the [Claude GitHub App](https://github.com/apps/claude) is installed on this repo (workflow stays inert until then)

## Test plan

- [ ] Merge, then comment \`@claude review this PR\` on a follow-up PR
- [ ] Watch the Actions tab — the \`Claude Code\` workflow should pick it up and Claude posts a reply
- [ ] Confirm checkout used the PR head SHA (not main) when triggered via PR conversation comment